### PR TITLE
Fix gems->plugins Deprecation Notice

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -64,7 +64,7 @@ defaults:
     values:
       image: true
 
-gems:
+plugins:
 - jekyll-sitemap
 - jekyll-seo-tag
 - jekyll-feed


### PR DESCRIPTION
When running `bundle exec jekyll serve`, we were getting a notice about
a deprecated configuration option:

$ bundle exec jekyll serve
Configuration file: /home/mkasberg/code/simpol-theme/_config.yml
       Deprecation: The 'gems' configuration option has been renamed to
       'plugins'. Please update your config file accordingly.

This happens on versions of Jekyll >=3.5. See the release notes:
https://jekyllrb.com/news/2017/06/15/jekyll-3-5-0-released/